### PR TITLE
Change elitekeyboards link to web.archive.org

### DIFF
--- a/src/pages-jaunes/index.md
+++ b/src/pages-jaunes/index.md
@@ -42,6 +42,7 @@ title: Pages Jaunes
 - <span class="flag-icon flag-icon-ca"></span> [https://matias.store/](https://matias.store/)
 - <span class="flag-icon flag-icon-us"></span> [https://mechanicalkeyboards.com/](https://mechanicalkeyboards.com/)
 - <span class="flag-icon flag-icon-us"></span> [https://elitekeyboards.com/](https://web.archive.org/web/20190414000543/http://elitekeyboards.com/)
+  - Ce lien redirige maintenant vers [web.archive.org](https://web.archive.org) car Elitekeyboards est définitivement fermé.
 - <span class="flag-icon flag-icon-us"></span> [https://www.massdrop.com/](https://www.massdrop.com/)
 - <span class="flag-icon flag-icon-us"></span> [https://originative.co/](https://originative.co/)
 - <span class="flag-icon flag-icon-au"></span> [https://ramaworks.store/](https://ramaworks.store/)

--- a/src/pages-jaunes/index.md
+++ b/src/pages-jaunes/index.md
@@ -41,7 +41,7 @@ title: Pages Jaunes
 - <span class="flag-icon flag-icon-de"></span> [https://uniqey.net/en](https://uniqey.net/en)
 - <span class="flag-icon flag-icon-ca"></span> [https://matias.store/](https://matias.store/)
 - <span class="flag-icon flag-icon-us"></span> [https://mechanicalkeyboards.com/](https://mechanicalkeyboards.com/)
-- <span class="flag-icon flag-icon-us"></span> [https://elitekeyboards.com/](https://elitekeyboards.com/)
+- <span class="flag-icon flag-icon-us"></span> [https://elitekeyboards.com/](https://web.archive.org/web/20190414000543/http://elitekeyboards.com/)
 - <span class="flag-icon flag-icon-us"></span> [https://www.massdrop.com/](https://www.massdrop.com/)
 - <span class="flag-icon flag-icon-us"></span> [https://originative.co/](https://originative.co/)
 - <span class="flag-icon flag-icon-au"></span> [https://ramaworks.store/](https://ramaworks.store/)


### PR DESCRIPTION
Elitekeyboards website seems to be dead since may-april 2019. This PR change the old url to the latest scan by web.archive.org

Using web.archive.org we are able to navigate the site.
See: https://web.archive.org/web/20190414000543/http://elitekeyboards.com/

This is not a official thread saying that elitekeyboards is dead but it seems like it really is: https://geekhack.org/index.php?topic=100824.0


Signed-off-by: Philippe Dagenais <pgdagenais@gmail.com>