### PR TITLE
Fix/minor updates homepage

### DIFF
--- a/src/includes/layouts/partials/_head.njk
+++ b/src/includes/layouts/partials/_head.njk
@@ -3,6 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="{{ '/' | url }}style.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css" integrity="sha256-UzFD2WYH2U1dQpKDjjZK72VtPeWP50NoJjd26rnAdUI=" crossorigin="anonymous"/>
+<meta name="theme-color" content="#00ACE7">
 
 
 <!--Twitter Card-->

--- a/src/includes/scss/_base.scss
+++ b/src/includes/scss/_base.scss
@@ -11,7 +11,6 @@ html {
   font-size: 62.5%;
 }
 
-html,
 body {
   height: 100%;
 }


### PR DESCRIPTION
For some reason, there was a height for the `html` tag which resulted in some annoying behavior for larger screen width.

Btw, usually we do use a flexbox wrapper nested directly into the `body` tag, pretty sure this bug is coming from the fact that we are directly using it on the `body` tag.

I added some basic color themed to website's color scheme.

![image](https://user-images.githubusercontent.com/5133074/61667041-3e066d00-acd9-11e9-940a-1a5106320d4b.png)
